### PR TITLE
v0.2.0-rc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.kitchen/*
+Berksfile.lock

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,18 @@
+---
+driver:
+  name: vagrant
+  customize: 
+     memory: 768
+  log_file: "/var/log/chef/chef-client.log"
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-14.04
+  - name: centos-7.1
+
+suites:
+  - name: default
+    run_list:
+      - recipe[duo-unix::default]

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.getchef.com'
+
+metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 duo-unix CHANGELOG
 =============
 
+0.2.0
+-----
+- [Vladimir Sudilovsky]
+    - Update defaults to duo-1.9.18
+    - open-ssh re-configured after duo installation
+    - support ubuntu, debian
+    - add serverspec integration tests via test-kitchen
+    - add Berkshelf support
+
 0.1.0
 -----
 - [Jason Rohwedder] - Initial release

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,7 +11,7 @@ default['duo-unix']['api']['host']              = nil
 default['duo-unix']['from_source']                  = true
 default['duo-unix']['src']['version']               = "1.9.18"
 default['duo-unix']['src']['url']                   = "https://dl.duosecurity.com/duo_unix-#{node['duo-unix']['src']['version']}.tar.gz"
-default['duo-unix']['src']['checksum']              = "ee667f65d47782c8082e477db7367aae"
+default['duo-unix']['src']['checksum']              = "2eb11dff0a173c62e318587c50faec717e8889fbb6bb2d076e4f31999f9107ae"
 
 # login_duo config
 default['duo-unix']['conf']['groups']               = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,13 +9,22 @@ default['duo-unix']['api']['host']              = nil
 
 # source
 default['duo-unix']['from_source']                  = true
-default['duo-unix']['src']['version']               = "1.9.7"
+default['duo-unix']['src']['version']               = "1.9.18"
 default['duo-unix']['src']['url']                   = "https://dl.duosecurity.com/duo_unix-#{node['duo-unix']['src']['version']}.tar.gz"
-default['duo-unix']['src']['checksum']              = "f200ea5accf3eafce66568ecb6f9f99634e84fac987bc06df11bd21e6dea1324"
+default['duo-unix']['src']['checksum']              = "ee667f65d47782c8082e477db7367aae"
+
 # login_duo config
-default['duo-unix']['conf']['group']                = nil
-default['duo-unix']['conf']['failmode']             = 'secure'
+default['duo-unix']['conf']['groups']               = nil
+default['duo-unix']['conf']['failmode']             = 'safe'
 default['duo-unix']['conf']['pushinfo']             = 'no'
+default['duo-unix']['conf']['http_proxy']           = nil
+default['duo-unix']['conf']['autopush']             = 'yes'
+default['duo-unix']['conf']['motd']             	= 'no'
+default['duo-unix']['conf']['prompts']             	= '1'
+default['duo-unix']['conf']['accept_env_factor']    = 'no'
+default['duo-unix']['conf']['fallback_local_ip']    = 'no'
+default['duo-unix']['conf']['https_timeout']    	= '0'
+
 # sshd config
 default['duo-unix']['sshd']['force_command']        = '/usr/sbin/login_duo'
 default['duo-unix']['sshd']['permit_tunnel']        = 'no'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,9 @@ maintainer_email 'jro@risk.io'
 license          'Apache 2.0'
 description      'Configures Duo 2-factor auth for unix'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.2.0'
 
 depends 'chef-vault'
 depends 'build-essential'
 depends 'openssh'
+depends 'apt'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'openssh::default'
+include_recipe 'apt' if ['ubuntu', 'debian'].include? node[:platform]
 include_recipe 'chef-vault'
 
 # determine install method
@@ -46,5 +46,5 @@ end
 
 # configure openssh to use login_duo
 node.default['openssh']['server'].merge!(node['duo-unix']['sshd'])
-
+include_recipe 'openssh::default'
 # TODO: add pam_duo support

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -27,8 +27,8 @@ when 'redhat', 'centos', 'fedora', 'amazon', 'scientific'
 end
   
 # get source
-src_dir = '/usr/local/src/duo_unix'
-tarball = '/usr/local/src/duo_unix.tar.gz'
+src_dir = "/usr/local/src/duo_unix-#{node['duo-unix']['src']['version']}"
+tarball = "/usr/local/src/duo_unix-#{node['duo-unix']['src']['version']}.tar.gz"
 remote_file tarball do
   source   node['duo-unix']['src']['url']
   checksum node['duo-unix']['src']['checksum']

--- a/templates/default/login_duo.conf.erb
+++ b/templates/default/login_duo.conf.erb
@@ -13,9 +13,9 @@ pushinfo = <%= @pushinfo %>
 autopush = <%= @autopush %>
 prompts = <%= @prompts %>
 motd = <%= @motd %>
-accept_env_factor = <%= accept_env_factor %>
-fallback_local_ip = <%= fallback_local_ip %>
-https_timeout = <%= https_timeout %>
+accept_env_factor = <%= @accept_env_factor %>
+fallback_local_ip = <%= @fallback_local_ip %>
+https_timeout = <%= @https_timeout %>
 
 <% if @http_proxy %>
 http_proxy = <%= @http_proxy %>

--- a/templates/default/login_duo.conf.erb
+++ b/templates/default/login_duo.conf.erb
@@ -1,15 +1,22 @@
 [duo]
-; Duo integration key
 ikey = <%= @ikey %>
-; Duo secret key
 skey = <%= @skey %>
-; Duo API host
 host = <%= @host %>
-<% if @group %>
+
+<% if @groups %>
 ; UNIX group that does 2-factor
-group = <%= @group %>
+groups = <%= @groups %>
 <% end -%>
-; Failure mode
+
 failmode = <%= @failmode %>
-; Send command for Duo Push authentication
 pushinfo = <%= @pushinfo %>
+autopush = <%= @autopush %>
+prompts = <%= @prompts %>
+motd = <%= @motd %>
+accept_env_factor = <%= accept_env_factor %>
+fallback_local_ip = <%= fallback_local_ip %>
+https_timeout = <%= https_timeout %>
+
+<% if @http_proxy %>
+http_proxy = <%= @http_proxy %>
+<% end -%>

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,25 @@
+require 'serverspec'
+
+# Required by serverspec
+set :backend, :exec
+
+describe service('sshd') do
+  it { should be_running }
+end
+
+describe file('/usr/sbin/login_duo') do
+  it { should exist }
+  it { should be_executable }
+end
+
+describe file('/etc/ssh/sshd_config') do
+  its(:content) { should contain "ForceCommand /usr/sbin/login_duo" }
+  its(:content) { should contain "PermitTunnel no" }
+  its(:content) { should contain "AllowTcpForwarding no" }
+end
+
+describe file('/etc/duo/login_duo.conf') do
+  its(:content) { should contain "ikey = " }
+  its(:content) { should contain "prompts = 1" }
+  its(:content) { should contain "autopush = yes" }
+end


### PR DESCRIPTION
Changelog:

    - Update defaults to duo-1.9.18
    - open-ssh re-configured after duo installation
    - support ubuntu, debian
    - add serverspec integration tests via test-kitchen
    - add Berkshelf support